### PR TITLE
Add Express-based teaching reflection assistant prototype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your_openai_api_key_here
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+uploads/*
+!uploads/.gitkeep
+.DS_Store
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# TeachRI Lesson Reflection Assistant
+
+This project is a Node.js + Express prototype designed for deployment on Render. It helps teachers reflect on classroom practice by combining lesson plans, research notes, and classroom transcripts with OpenAI's APIs.
+
+## Features
+
+- Upload classroom audio to request speech-to-text transcription via OpenAI's `gpt-4o-mini-transcribe` model.
+- Submit transcription JSON, research references, and lesson plan text to generate tailored coaching insights using the `gpt-4.1-mini` model.
+- Simple responsive UI for quick testing and iteration.
+
+## Prerequisites
+
+- Node.js 18+
+- An OpenAI API key with access to `gpt-4o-mini-transcribe` and `gpt-4.1-mini`
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+   > If you are running in an environment without external network access, install packages locally before deployment.
+
+2. Copy the example environment file and add your OpenAI API key:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Update `.env`:
+
+   ```dotenv
+   OPENAI_API_KEY=sk-your-key
+   PORT=3000 # optional override
+   ```
+
+3. Start the development server:
+
+   ```bash
+   npm run start
+   ```
+
+4. Open `http://localhost:3000` in your browser and submit the form to generate coaching feedback.
+
+## Deployment on Render
+
+1. Push this repository to your Git provider.
+2. Create a new **Web Service** on Render targeting the repo.
+3. Set the build command to `npm install` and the start command to `npm run start`.
+4. Add the `OPENAI_API_KEY` environment variable in Render's dashboard.
+
+## API Routes
+
+- `POST /api/transcribe`: Accepts `multipart/form-data` with an `audio` file field. Returns JSON from OpenAI's speech-to-text API.
+- `POST /api/analyze`: Accepts JSON with `transcriptionJson`, `researchText`, and `lessonPlan` fields. Returns generated coaching feedback.
+
+## Notes
+
+- Uploaded audio files are stored temporarily on disk and deleted after transcription completes.
+- The UI includes placeholder text for quick testing when no audio is available.
+- Remember to handle usage costs and guard against prompt injection when preparing for production.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "teachri",
+  "version": "1.0.0",
+  "description": "Teacher reflection insights tool",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js",
+    "test": "echo \"No automated tests configured\""
+  },
+  "keywords": ["education", "openai", "express"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "openai": "^4.58.1"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TeachRI - Lesson Reflection Assistant</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="container">
+    <header>
+      <h1>TeachRI Lesson Reflection Assistant</h1>
+      <p>Upload your lesson materials to receive targeted coaching insights.</p>
+    </header>
+
+    <section class="card">
+      <h2>Classroom Audio (Optional)</h2>
+      <p class="hint">Audio transcription runs through OpenAI Speech-to-Text when a file is provided.</p>
+      <form id="transcription-form" enctype="multipart/form-data">
+        <input type="file" id="audio" name="audio" accept="audio/*" />
+        <button type="submit">Transcribe Audio</button>
+      </form>
+      <pre id="transcription-result" class="code-block hidden"></pre>
+    </section>
+
+    <section class="card">
+      <h2>Generate Feedback</h2>
+      <form id="analysis-form">
+        <label for="transcriptionJson">Transcription JSON with timestamps</label>
+        <textarea id="transcriptionJson" name="transcriptionJson" rows="10">[
+  {
+    "timestamp": "00:00-00:45",
+    "speaker": "Teacher",
+    "text": "Good morning everyone! Today we're exploring ecosystems."
+  },
+  {
+    "timestamp": "00:45-01:30",
+    "speaker": "Student A",
+    "text": "An ecosystem is where living and non-living things interact."
+  },
+  {
+    "timestamp": "01:30-02:15",
+    "speaker": "Teacher",
+    "text": "Exactly. Turn to your partner and discuss how humans impact local ecosystems."
+  }
+]</textarea>
+
+        <label for="researchText">Research Notes</label>
+        <textarea id="researchText" name="researchText" rows="6">Placeholder research note: Focus on inquiry-based learning to support student agency and use formative feedback techniques (Black & Wiliam, 2018).</textarea>
+
+        <label for="lessonPlan">Lesson Plan Overview</label>
+        <textarea id="lessonPlan" name="lessonPlan" rows="6">Lesson Objective: Students will describe how human actions can support or disrupt the balance of local ecosystems.\nPlanned Activities: Warm-up question, mini-lecture, partner discussion, exit ticket reflection.</textarea>
+
+        <button type="submit">Generate Coaching Feedback</button>
+      </form>
+      <section id="feedback" class="card hidden">
+        <h3>Coaching Insights</h3>
+        <article id="feedback-content"></article>
+      </section>
+    </section>
+  </main>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,97 @@
+const transcriptionForm = document.getElementById('transcription-form');
+const transcriptionResult = document.getElementById('transcription-result');
+const analysisForm = document.getElementById('analysis-form');
+const feedbackSection = document.getElementById('feedback');
+const feedbackContent = document.getElementById('feedback-content');
+
+function setButtonState(button, loading, defaultLabel) {
+  if (!button) return;
+  button.disabled = loading;
+  button.textContent = loading ? 'Working…' : defaultLabel;
+}
+
+async function handleTranscription(event) {
+  event.preventDefault();
+  const submitButton = transcriptionForm.querySelector('button[type="submit"]');
+  const audioInput = document.getElementById('audio');
+
+  if (!audioInput.files?.length) {
+    transcriptionResult.textContent = 'Please choose an audio file before submitting.';
+    transcriptionResult.classList.remove('hidden');
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('audio', audioInput.files[0]);
+
+  setButtonState(submitButton, true, 'Transcribe Audio');
+  transcriptionResult.classList.add('hidden');
+
+  try {
+    const response = await fetch('/api/transcribe', {
+      method: 'POST',
+      body: formData
+    });
+
+    const payload = await response.json();
+
+    if (!response.ok) {
+      throw new Error(payload.error || 'Unable to transcribe audio.');
+    }
+
+    transcriptionResult.textContent = JSON.stringify(payload.transcription, null, 2);
+    transcriptionResult.classList.remove('hidden');
+    document.getElementById('transcriptionJson').value = JSON.stringify(payload.transcription, null, 2);
+  } catch (error) {
+    transcriptionResult.textContent = error.message;
+    transcriptionResult.classList.remove('hidden');
+  } finally {
+    setButtonState(submitButton, false, 'Transcribe Audio');
+  }
+}
+
+async function handleAnalysis(event) {
+  event.preventDefault();
+  const submitButton = analysisForm.querySelector('button[type="submit"]');
+  setButtonState(submitButton, true, 'Generate Coaching Feedback');
+  feedbackSection.classList.add('hidden');
+  feedbackContent.innerHTML = '';
+
+  const payload = {
+    transcriptionJson: analysisForm.transcriptionJson.value.trim(),
+    researchText: analysisForm.researchText.value.trim(),
+    lessonPlan: analysisForm.lessonPlan.value.trim()
+  };
+
+  try {
+    const response = await fetch('/api/analyze', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to generate coaching insights.');
+    }
+
+    const formatted = (data.feedback || '').split('\n').map((paragraph) => paragraph.trim()).filter(Boolean);
+
+    feedbackContent.innerHTML = formatted.map((paragraph) => `<p>${paragraph}</p>`).join('');
+    feedbackSection.classList.remove('hidden');
+  } catch (error) {
+    feedbackContent.innerHTML = `<p>${error.message}</p>`;
+    feedbackSection.classList.remove('hidden');
+  } finally {
+    setButtonState(submitButton, false, 'Generate Coaching Feedback');
+  }
+}
+
+if (transcriptionForm) {
+  transcriptionForm.addEventListener('submit', handleTranscription);
+}
+
+if (analysisForm) {
+  analysisForm.addEventListener('submit', handleAnalysis);
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,109 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.6;
+  --accent: #2563eb;
+  --bg: #f8fafc;
+  --card: #ffffffd9;
+  --border: #e2e8f0;
+  --text: #0f172a;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  margin-bottom: 0.5rem;
+  font-size: 2.2rem;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 20px 45px -30px rgba(15, 23, 42, 0.4);
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 1rem;
+  font-size: 0.95rem;
+  resize: vertical;
+  min-height: 120px;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+textarea:focus {
+  outline: 2px solid var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+button {
+  margin-top: 1.5rem;
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px -18px rgba(37, 99, 235, 0.8);
+}
+
+button:disabled {
+  background: #cbd5f5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.code-block {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 12px;
+  overflow-x: auto;
+  font-size: 0.85rem;
+}
+
+.hint {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.hidden {
+  display: none;
+}
+
+#feedback-content p {
+  margin-top: 0;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,143 @@
+import express from 'express';
+import cors from 'cors';
+import multer from 'multer';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+import OpenAI from 'openai';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const upload = multer({ dest: path.join(__dirname, 'uploads') });
+
+const port = process.env.PORT || 3000;
+const openaiApiKey = process.env.OPENAI_API_KEY;
+
+if (!openaiApiKey) {
+  console.warn('Warning: OPENAI_API_KEY is not set. API routes will fail until it is provided.');
+}
+
+const openai = new OpenAI({ apiKey: openaiApiKey });
+
+app.use(cors());
+app.use(express.json({ limit: '5mb' }));
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.post('/api/transcribe', upload.single('audio'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No audio file uploaded.' });
+  }
+
+  if (!openaiApiKey) {
+    fs.unlink(req.file.path, () => {});
+    return res.status(500).json({ error: 'OpenAI API key not configured on the server.' });
+  }
+
+  try {
+    const transcription = await openai.audio.transcriptions.create({
+      file: fs.createReadStream(req.file.path),
+      model: 'gpt-4o-mini-transcribe'
+    });
+
+    fs.unlink(req.file.path, () => {});
+
+    return res.json({ transcription });
+  } catch (error) {
+    console.error('Transcription error:', error);
+    fs.unlink(req.file.path, () => {});
+    return res.status(500).json({
+      error: 'Failed to transcribe audio with OpenAI.',
+      details: error?.response?.data || error.message
+    });
+  }
+});
+
+app.post('/api/analyze', async (req, res) => {
+  const { transcriptionJson, researchText, lessonPlan } = req.body || {};
+
+  if (!transcriptionJson || !researchText || !lessonPlan) {
+    return res.status(400).json({
+      error: 'transcriptionJson, researchText, and lessonPlan are required fields.'
+    });
+  }
+
+  if (!openaiApiKey) {
+    return res.status(500).json({ error: 'OpenAI API key not configured on the server.' });
+  }
+
+  let parsedTranscript;
+  let transcriptSummary = '';
+
+  try {
+    parsedTranscript = JSON.parse(transcriptionJson);
+  } catch (parseError) {
+    console.warn('Could not parse transcription JSON, sending raw string.');
+  }
+
+  if (Array.isArray(parsedTranscript)) {
+    transcriptSummary = parsedTranscript
+      .map((entry, index) => {
+        const timestamp = entry?.timestamp ?? entry?.start ?? `segment-${index + 1}`;
+        const speaker = entry?.speaker ? `${entry.speaker}: ` : '';
+        const text = entry?.text || JSON.stringify(entry);
+        return `(${timestamp}) ${speaker}${text}`;
+      })
+      .join('\n');
+  } else if (typeof parsedTranscript === 'object' && parsedTranscript !== null) {
+    transcriptSummary = JSON.stringify(parsedTranscript, null, 2);
+  } else {
+    transcriptSummary = transcriptionJson;
+  }
+
+  const prompt = `You are a supportive instructional coach helping teachers reflect on their practice.\n` +
+    `Use the provided lesson plan, any research references, and the classroom transcript to create:\n` +
+    `1. A warm summary of the lesson strengths.\n` +
+    `2. Specific, actionable suggestions for improvement aligned to the teacher's plan.\n` +
+    `3. Connections to the referenced research when relevant.\n` +
+    `4. A short set of next steps for the teacher.\n` +
+    `Keep the tone encouraging, specific, and professional.`;
+
+  try {
+    const response = await openai.responses.create({
+      model: 'gpt-4.1-mini',
+      input: [
+        {
+          role: 'system',
+          content: prompt
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Lesson Plan:\n' + lessonPlan },
+            { type: 'text', text: '\nResearch References:\n' + researchText },
+            { type: 'text', text: '\nClassroom Transcript Summary:\n' + transcriptSummary }
+          ]
+        }
+      ]
+    });
+
+    return res.json({
+      feedback: response.output_text || 'No response text was returned from the model.'
+    });
+  } catch (error) {
+    console.error('Analysis error:', error);
+    return res.status(500).json({
+      error: 'Failed to generate feedback with OpenAI.',
+      details: error?.response?.data || error.message
+    });
+  }
+});
+
+app.use((req, res) => {
+  res.status(404).json({ error: 'Route not found.' });
+});
+
+app.listen(port, () => {
+  console.log(`TeachRI server running on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- set up an Express server that proxies audio transcription requests to OpenAI and generates coaching feedback with gpt-4.1-mini
- build a simple front-end with forms for audio upload, transcription JSON, research notes, and lesson plan text
- document local setup, environment configuration, and Render deployment steps

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52071dec48327a5e0bb22f57e16cd