### PR TITLE
Add sample-friendly fallbacks and polish UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is a Node.js + Express prototype designed for deployment on Render.
 
 - Upload classroom audio to request speech-to-text transcription via OpenAI's `gpt-4o-mini-transcribe` model.
 - Submit transcription JSON, research references, and lesson plan text to generate tailored coaching insights using the `gpt-4.1-mini` model.
-- Simple responsive UI for quick testing and iteration.
+- Simple responsive UI with built-in sample data for quick testing and iteration.
 
 ## Prerequisites
 
@@ -53,11 +53,11 @@ This project is a Node.js + Express prototype designed for deployment on Render.
 
 ## API Routes
 
-- `POST /api/transcribe`: Accepts `multipart/form-data` with an `audio` file field. Returns JSON from OpenAI's speech-to-text API.
-- `POST /api/analyze`: Accepts JSON with `transcriptionJson`, `researchText`, and `lessonPlan` fields. Returns generated coaching feedback.
+- `POST /api/transcribe`: Accepts `multipart/form-data` with an `audio` file field. Returns JSON from OpenAI's speech-to-text API or a locally generated sample when no audio/API key is available.
+- `POST /api/analyze`: Accepts JSON with `transcriptionJson`, `researchText`, and `lessonPlan` fields. Returns generated coaching feedback or a locally generated sample when OpenAI access is unavailable.
 
 ## Notes
 
 - Uploaded audio files are stored temporarily on disk and deleted after transcription completes.
-- The UI includes placeholder text for quick testing when no audio is available.
+- The UI includes built-in sample transcription, research, and lesson plan data that can be previewed without any API calls.
 - Remember to handle usage costs and guard against prompt injection when preparing for production.

--- a/public/index.html
+++ b/public/index.html
@@ -10,53 +10,46 @@
   <main class="container">
     <header>
       <h1>TeachRI Lesson Reflection Assistant</h1>
-      <p>Upload your lesson materials to receive targeted coaching insights.</p>
+      <p>Upload lesson artifacts or work with the built-in samples to preview instructional coaching insights instantly.</p>
     </header>
 
-    <section class="card">
-      <h2>Classroom Audio (Optional)</h2>
-      <p class="hint">Audio transcription runs through OpenAI Speech-to-Text when a file is provided.</p>
-      <form id="transcription-form" enctype="multipart/form-data">
-        <input type="file" id="audio" name="audio" accept="audio/*" />
-        <button type="submit">Transcribe Audio</button>
-      </form>
-      <pre id="transcription-result" class="code-block hidden"></pre>
-    </section>
-
-    <section class="card">
-      <h2>Generate Feedback</h2>
-      <form id="analysis-form">
-        <label for="transcriptionJson">Transcription JSON with timestamps</label>
-        <textarea id="transcriptionJson" name="transcriptionJson" rows="10">[
-  {
-    "timestamp": "00:00-00:45",
-    "speaker": "Teacher",
-    "text": "Good morning everyone! Today we're exploring ecosystems."
-  },
-  {
-    "timestamp": "00:45-01:30",
-    "speaker": "Student A",
-    "text": "An ecosystem is where living and non-living things interact."
-  },
-  {
-    "timestamp": "01:30-02:15",
-    "speaker": "Teacher",
-    "text": "Exactly. Turn to your partner and discuss how humans impact local ecosystems."
-  }
-]</textarea>
-
-        <label for="researchText">Research Notes</label>
-        <textarea id="researchText" name="researchText" rows="6">Placeholder research note: Focus on inquiry-based learning to support student agency and use formative feedback techniques (Black & Wiliam, 2018).</textarea>
-
-        <label for="lessonPlan">Lesson Plan Overview</label>
-        <textarea id="lessonPlan" name="lessonPlan" rows="6">Lesson Objective: Students will describe how human actions can support or disrupt the balance of local ecosystems.\nPlanned Activities: Warm-up question, mini-lecture, partner discussion, exit ticket reflection.</textarea>
-
-        <button type="submit">Generate Coaching Feedback</button>
-      </form>
-      <section id="feedback" class="card hidden">
-        <h3>Coaching Insights</h3>
-        <article id="feedback-content"></article>
+    <div class="card-grid">
+      <section class="card">
+        <h2>Classroom Audio (Optional)</h2>
+        <p class="hint">Upload a recording to transcribe it with OpenAI or skip the upload to view a sample transcript.</p>
+        <form id="transcription-form" enctype="multipart/form-data">
+          <label class="sr-only" for="audio">Classroom audio upload</label>
+          <input type="file" id="audio" name="audio" accept="audio/*" />
+          <div class="button-row">
+            <button type="submit">Transcribe Audio</button>
+            <button type="button" id="load-sample" class="ghost">Use Sample Data</button>
+          </div>
+        </form>
+        <p id="transcription-note" class="status-note hidden" role="status" aria-live="polite"></p>
+        <pre id="transcription-result" class="code-block hidden" aria-live="polite"></pre>
       </section>
+
+      <section class="card">
+        <h2>Generate Feedback</h2>
+        <form id="analysis-form">
+          <label for="transcriptionJson">Transcription JSON with timestamps</label>
+          <textarea id="transcriptionJson" name="transcriptionJson" rows="10"></textarea>
+
+          <label for="researchText">Research Notes</label>
+          <textarea id="researchText" name="researchText" rows="6"></textarea>
+
+          <label for="lessonPlan">Lesson Plan Overview</label>
+          <textarea id="lessonPlan" name="lessonPlan" rows="6"></textarea>
+
+          <button type="submit">Generate Coaching Feedback</button>
+        </form>
+      </section>
+    </div>
+
+    <section id="feedback" class="card hidden feedback-card">
+      <h3>Coaching Insights</h3>
+      <p id="feedback-note" class="status-note hidden" role="status" aria-live="polite"></p>
+      <article id="feedback-content"></article>
     </section>
   </main>
 

--- a/public/main.js
+++ b/public/main.js
@@ -1,8 +1,79 @@
 const transcriptionForm = document.getElementById('transcription-form');
 const transcriptionResult = document.getElementById('transcription-result');
+const transcriptionNote = document.getElementById('transcription-note');
+const loadSampleButton = document.getElementById('load-sample');
 const analysisForm = document.getElementById('analysis-form');
 const feedbackSection = document.getElementById('feedback');
 const feedbackContent = document.getElementById('feedback-content');
+const feedbackNote = document.getElementById('feedback-note');
+
+const SAMPLE_SEGMENTS = [
+  {
+    timestamp: '00:00-00:45',
+    speaker: 'Teacher',
+    text: "Good morning everyone! Today we're exploring ecosystems."
+  },
+  {
+    timestamp: '00:45-01:30',
+    speaker: 'Student A',
+    text: 'An ecosystem is where living and non-living things interact.'
+  },
+  {
+    timestamp: '01:30-02:15',
+    speaker: 'Teacher',
+    text: 'Exactly. Turn to your partner and discuss how humans impact local ecosystems.'
+  }
+];
+
+const SAMPLE_TRANSCRIPTION = {
+  text: 'Sample transcription generated locally.',
+  segments: SAMPLE_SEGMENTS
+};
+
+const SAMPLE_RESEARCH = 'Focus on inquiry-based learning to support student agency and embed formative feedback checkpoints (Black & Wiliam, 2018).';
+
+const SAMPLE_LESSON_PLAN = 'Lesson Objective: Students will describe how human actions can support or disrupt the balance of local ecosystems.\nPlanned Activities: Warm-up question, mini-lesson, partner discussion, exit ticket reflection.';
+
+const SAMPLE_FEEDBACK = `Lesson strengths\n- Students engaged in collaborative dialogue and used academic vocabulary to describe ecosystems.\n- The lesson objective was revisited throughout the discussion which kept learners focused.\n\nSuggestions\n- Include a quick formative check (thumbs up/down or digital poll) to capture every student voice.\n- Provide a sentence stem or graphic organizer to support learners who need structure in partner discussions.\n\nNext steps\n1. Capture student ideas on an anchor chart to revisit next class.\n2. Ask students to connect their discussion to a real-world action they can take this week.`;
+
+function showNote(element, message) {
+  if (!element) return;
+  if (message) {
+    element.textContent = message;
+    element.classList.remove('hidden');
+  } else {
+    element.textContent = '';
+    element.classList.add('hidden');
+  }
+}
+
+function renderTranscription(transcription, note) {
+  if (!transcriptionResult) return;
+  const serialised = typeof transcription === 'string'
+    ? transcription
+    : JSON.stringify(transcription, null, 2);
+  transcriptionResult.textContent = serialised;
+  transcriptionResult.classList.remove('hidden');
+  showNote(transcriptionNote, note);
+}
+
+function populateSampleForm() {
+  if (!analysisForm) return;
+  analysisForm.transcriptionJson.value = JSON.stringify(SAMPLE_SEGMENTS, null, 2);
+  analysisForm.researchText.value = SAMPLE_RESEARCH;
+  analysisForm.lessonPlan.value = SAMPLE_LESSON_PLAN;
+}
+
+function renderFeedback(feedback, note) {
+  if (!feedbackSection || !feedbackContent) return;
+  const formatted = (feedback || '')
+    .split('\n')
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+  feedbackContent.innerHTML = formatted.map((paragraph) => `<p>${paragraph}</p>`).join('');
+  feedbackSection.classList.remove('hidden');
+  showNote(feedbackNote, note);
+}
 
 function setButtonState(button, loading, defaultLabel) {
   if (!button) return;
@@ -15,14 +86,10 @@ async function handleTranscription(event) {
   const submitButton = transcriptionForm.querySelector('button[type="submit"]');
   const audioInput = document.getElementById('audio');
 
-  if (!audioInput.files?.length) {
-    transcriptionResult.textContent = 'Please choose an audio file before submitting.';
-    transcriptionResult.classList.remove('hidden');
-    return;
-  }
-
   const formData = new FormData();
-  formData.append('audio', audioInput.files[0]);
+  if (audioInput.files?.length) {
+    formData.append('audio', audioInput.files[0]);
+  }
 
   setButtonState(submitButton, true, 'Transcribe Audio');
   transcriptionResult.classList.add('hidden');
@@ -39,12 +106,11 @@ async function handleTranscription(event) {
       throw new Error(payload.error || 'Unable to transcribe audio.');
     }
 
-    transcriptionResult.textContent = JSON.stringify(payload.transcription, null, 2);
-    transcriptionResult.classList.remove('hidden');
-    document.getElementById('transcriptionJson').value = JSON.stringify(payload.transcription, null, 2);
+    renderTranscription(payload.transcription, payload.note);
+    const serialisedSegments = payload.transcription?.segments || payload.transcription;
+    analysisForm.transcriptionJson.value = JSON.stringify(serialisedSegments, null, 2);
   } catch (error) {
-    transcriptionResult.textContent = error.message;
-    transcriptionResult.classList.remove('hidden');
+    renderTranscription(error.message, 'There was an issue transcribing audio. Showing the error message below.');
   } finally {
     setButtonState(submitButton, false, 'Transcribe Audio');
   }
@@ -56,6 +122,7 @@ async function handleAnalysis(event) {
   setButtonState(submitButton, true, 'Generate Coaching Feedback');
   feedbackSection.classList.add('hidden');
   feedbackContent.innerHTML = '';
+  showNote(feedbackNote, '');
 
   const payload = {
     transcriptionJson: analysisForm.transcriptionJson.value.trim(),
@@ -76,13 +143,9 @@ async function handleAnalysis(event) {
       throw new Error(data.error || 'Failed to generate coaching insights.');
     }
 
-    const formatted = (data.feedback || '').split('\n').map((paragraph) => paragraph.trim()).filter(Boolean);
-
-    feedbackContent.innerHTML = formatted.map((paragraph) => `<p>${paragraph}</p>`).join('');
-    feedbackSection.classList.remove('hidden');
+    renderFeedback(data.feedback, data.note);
   } catch (error) {
-    feedbackContent.innerHTML = `<p>${error.message}</p>`;
-    feedbackSection.classList.remove('hidden');
+    renderFeedback(error.message, 'There was an issue generating insights. Showing the error message below.');
   } finally {
     setButtonState(submitButton, false, 'Generate Coaching Feedback');
   }
@@ -95,3 +158,15 @@ if (transcriptionForm) {
 if (analysisForm) {
   analysisForm.addEventListener('submit', handleAnalysis);
 }
+
+if (loadSampleButton) {
+  loadSampleButton.addEventListener('click', () => {
+    renderTranscription(SAMPLE_TRANSCRIPTION, 'Sample transcription loaded.');
+    populateSampleForm();
+    renderFeedback(SAMPLE_FEEDBACK, 'Sample feedback loaded. Submit the form to request fresh insights.');
+  });
+}
+
+populateSampleForm();
+renderTranscription(SAMPLE_TRANSCRIPTION, 'Sample transcription ready to preview. Upload audio to replace it.');
+renderFeedback(SAMPLE_FEEDBACK, 'Sample feedback ready to preview. Submit the form to request fresh insights.');

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,81 +3,128 @@
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.14);
   --bg: #f8fafc;
-  --card: #ffffffd9;
+  --card: rgba(255, 255, 255, 0.95);
   --border: #e2e8f0;
   --text: #0f172a;
+  --muted: #64748b;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: var(--bg);
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.08), transparent 60%),
+    var(--bg);
   color: var(--text);
 }
 
 .container {
-  max-width: 960px;
+  max-width: 1080px;
   margin: 0 auto;
-  padding: 2rem 1rem 4rem;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
 header {
   text-align: center;
-  margin-bottom: 2rem;
+  display: grid;
+  gap: 0.75rem;
 }
 
 header h1 {
-  margin-bottom: 0.5rem;
-  font-size: 2.2rem;
+  margin: 0;
+  font-size: clamp(2rem, 2.8vw + 1.2rem, 3rem);
+  letter-spacing: -0.02em;
+}
+
+header p {
+  margin: 0 auto;
+  max-width: 42rem;
+  color: var(--muted);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
 }
 
 .card {
   background: var(--card);
   border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 1.5rem;
-  margin-bottom: 2rem;
-  box-shadow: 0 20px 45px -30px rgba(15, 23, 42, 0.4);
+  border-radius: 20px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 25px 45px -35px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(6px);
+}
+
+.card h2,
+.card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 label {
-  display: block;
   font-weight: 600;
-  margin-top: 1.25rem;
-  margin-bottom: 0.5rem;
+  color: var(--text);
+}
+
+textarea,
+input[type='file'] {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  padding: 0.9rem 1rem;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.96);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 textarea {
-  width: 100%;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  padding: 1rem;
-  font-size: 0.95rem;
   resize: vertical;
   min-height: 120px;
-  background: rgba(255, 255, 255, 0.92);
 }
 
-textarea:focus {
-  outline: 2px solid var(--accent);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+textarea:focus,
+input[type='file']:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 button {
-  margin-top: 1.5rem;
   background: var(--accent);
   color: white;
   border: none;
-  padding: 0.85rem 1.8rem;
+  padding: 0.85rem 1.9rem;
   border-radius: 999px;
   font-size: 1rem;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
 }
 
 button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 30px -18px rgba(37, 99, 235, 0.8);
+  box-shadow: 0 14px 30px -18px rgba(37, 99, 235, 0.9);
 }
 
 button:disabled {
@@ -86,24 +133,93 @@ button:disabled {
   box-shadow: none;
 }
 
+.ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  box-shadow: none;
+}
+
+.ghost:hover {
+  background: var(--accent-soft);
+  transform: none;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 .code-block {
   background: #0f172a;
   color: #e2e8f0;
-  padding: 1rem;
-  border-radius: 12px;
-  overflow-x: auto;
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
   font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow-y: auto;
 }
 
 .hint {
-  color: #64748b;
-  font-size: 0.9rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+  margin: 0;
 }
 
 .hidden {
-  display: none;
+  display: none !important;
+}
+
+.status-note {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  color: var(--accent);
+  font-size: 0.92rem;
+}
+
+#feedback-content {
+  display: grid;
+  gap: 0.9rem;
 }
 
 #feedback-content p {
-  margin-top: 0;
+  margin: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .container {
+    padding: 1.75rem 1.1rem 3rem;
+  }
+
+  .card {
+    padding: 1.35rem;
+  }
+
+  .button-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ghost,
+  button {
+    width: 100%;
+  }
 }

--- a/server.js
+++ b/server.js
@@ -12,9 +12,6 @@ dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const app = express();
-const upload = multer({ dest: path.join(__dirname, 'uploads') });
-
 const port = process.env.PORT || 3000;
 const openaiApiKey = process.env.OPENAI_API_KEY;
 
@@ -22,7 +19,48 @@ if (!openaiApiKey) {
   console.warn('Warning: OPENAI_API_KEY is not set. API routes will fail until it is provided.');
 }
 
-const openai = new OpenAI({ apiKey: openaiApiKey });
+const openai = openaiApiKey ? new OpenAI({ apiKey: openaiApiKey }) : null;
+
+const SAMPLE_TRANSCRIPTION = {
+  text: 'Sample transcription generated locally.',
+  segments: [
+    {
+      id: 1,
+      start: '00:00',
+      end: '00:45',
+      speaker: 'Teacher',
+      text: 'Good morning everyone! Today we are exploring ecosystems and how they change over time.'
+    },
+    {
+      id: 2,
+      start: '00:45',
+      end: '01:12',
+      speaker: 'Student A',
+      text: 'An ecosystem is the relationship between living things and the environment around them.'
+    },
+    {
+      id: 3,
+      start: '01:12',
+      end: '02:04',
+      speaker: 'Teacher',
+      text: 'Turn and talk with a partner about ways our class can protect the pollinator garden this spring.'
+    }
+  ]
+};
+
+const SAMPLE_FEEDBACK = `Lesson strengths\n- Students engaged in collaborative dialogue and used academic vocabulary to describe ecosystems.\n- The lesson objective was revisited throughout the discussion which kept learners focused.\n\nSuggestions\n- Include a quick formative check (thumbs up/down or digital poll) to capture every student voice.\n- Provide a sentence stem or graphic organizer to support learners who need structure in partner discussions.\n\nNext steps\n1. Capture student ideas on an anchor chart to revisit next class.\n2. Ask students to connect their discussion to a real-world action they can take this week.`;
+
+function ensureUploadsDir() {
+  const uploadsPath = path.join(__dirname, 'uploads');
+  if (!fs.existsSync(uploadsPath)) {
+    fs.mkdirSync(uploadsPath, { recursive: true });
+  }
+}
+
+ensureUploadsDir();
+
+const app = express();
+const upload = multer({ dest: path.join(__dirname, 'uploads') });
 
 app.use(cors());
 app.use(express.json({ limit: '5mb' }));
@@ -31,15 +69,18 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.post('/api/transcribe', upload.single('audio'), async (req, res) => {
   if (!req.file) {
-    return res.status(400).json({ error: 'No audio file uploaded.' });
-  }
-
-  if (!openaiApiKey) {
-    fs.unlink(req.file.path, () => {});
-    return res.status(500).json({ error: 'OpenAI API key not configured on the server.' });
+    return res.json({
+      transcription: SAMPLE_TRANSCRIPTION,
+      note: 'No audio uploaded. Returned sample transcription so you can test the UI.'
+    });
   }
 
   try {
+    if (!openaiApiKey || !openai) {
+      fs.unlink(req.file.path, () => {});
+      return res.json({ transcription: SAMPLE_TRANSCRIPTION, note: 'Returned sample transcription because no API key was configured.' });
+    }
+
     const transcription = await openai.audio.transcriptions.create({
       file: fs.createReadStream(req.file.path),
       model: 'gpt-4o-mini-transcribe'
@@ -51,6 +92,9 @@ app.post('/api/transcribe', upload.single('audio'), async (req, res) => {
   } catch (error) {
     console.error('Transcription error:', error);
     fs.unlink(req.file.path, () => {});
+    if (!openaiApiKey || !openai) {
+      return res.json({ transcription: SAMPLE_TRANSCRIPTION, note: 'Returned sample transcription because the OpenAI request could not be completed.' });
+    }
     return res.status(500).json({
       error: 'Failed to transcribe audio with OpenAI.',
       details: error?.response?.data || error.message
@@ -65,10 +109,6 @@ app.post('/api/analyze', async (req, res) => {
     return res.status(400).json({
       error: 'transcriptionJson, researchText, and lessonPlan are required fields.'
     });
-  }
-
-  if (!openaiApiKey) {
-    return res.status(500).json({ error: 'OpenAI API key not configured on the server.' });
   }
 
   let parsedTranscript;
@@ -104,6 +144,13 @@ app.post('/api/analyze', async (req, res) => {
     `Keep the tone encouraging, specific, and professional.`;
 
   try {
+    if (!openaiApiKey || !openai) {
+      return res.json({
+        feedback: SAMPLE_FEEDBACK,
+        note: 'Returned sample feedback because no API key was configured.'
+      });
+    }
+
     const response = await openai.responses.create({
       model: 'gpt-4.1-mini',
       input: [
@@ -127,6 +174,12 @@ app.post('/api/analyze', async (req, res) => {
     });
   } catch (error) {
     console.error('Analysis error:', error);
+    if (!openaiApiKey || !openai) {
+      return res.json({
+        feedback: SAMPLE_FEEDBACK,
+        note: 'Returned sample feedback because the OpenAI request could not be completed.'
+      });
+    }
     return res.status(500).json({
       error: 'Failed to generate feedback with OpenAI.',
       details: error?.response?.data || error.message


### PR DESCRIPTION
## Summary
- add local sample transcription and feedback fallbacks so the API can be tested without an OpenAI key
- refresh the public UI with responsive cards, sample data shortcuts, and inline status messaging
- document the new sample behaviour in the README for quick onboarding

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5748380008327a999c65caabbea03